### PR TITLE
Added missing dependency (chainy-plugin-log)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "chainy-core": "1",
     "chainy-plugin-exec": "1",
     "chainy-plugin-each": "1",
+    "chainy-plugin-log": "1",
     "chainy-plugin-map": "1",
     "chainy-plugin-set": "1",
     "extendr": "^2.1.0",


### PR DESCRIPTION
Hey Ben, when using `chainy install common` it gave me the following errors:

```
$ chainy install common               

/home/greduan/.nvm/v0.10.29/lib/node_modules/chainy-cli/node_modules/chainy-core/lib/chainy.js:409
        throw this.getRequirePluginError(pluginName)
                   ^
Error: Failed to require the plugin: log
You may need to install it manually: npm install --save chainy-plugin-log
    at Chainy.getRequirePluginError.Chainy.getRequirePluginError (/home/greduan/.nvm/v0.10.29/lib/node_modules/chainy-cli/node_modules/chainy-core/lib/chainy.js:422:12)
    at Chainy.requirePlugin.Chainy.requirePlugin (/home/greduan/.nvm/v0.10.29/lib/node_modules/chainy-cli/node_modules/chainy-core/lib/chainy.js:409:14)
    at /home/greduan/.nvm/v0.10.29/lib/node_modules/chainy-cli/node_modules/chainy-core/lib/chainy.js:488:15
    at Array.forEach (native)
    at Chainy.require.Chainy.require (/home/greduan/.nvm/v0.10.29/lib/node_modules/chainy-cli/node_modules/chainy-core/lib/chainy.js:474:10)
    at Object.<anonymous> (/home/greduan/.nvm/v0.10.29/lib/node_modules/chainy-cli/lib/chainy-cli.js:27:48)
    at Module._compile (module.js:456:26)
    at Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Module._load (module.js:312:12)
```

So I went into the `chainy-cli` module in my global folder and installed 'log' and that seems to have fixed it, so I add it here.
